### PR TITLE
'guage' => 'gauge' typo fix

### DIFF
--- a/NStatsD.Client.Demo/Program.cs
+++ b/NStatsD.Client.Demo/Program.cs
@@ -12,7 +12,7 @@ namespace Demo
             NStatsD.Client.Current.Increment("test.increment");
             NStatsD.Client.Current.Decrement("test.decrement");
             NStatsD.Client.Current.Timing("test.increment", timer.ElapsedMilliseconds);
-            NStatsD.Client.Current.Guage("test.guage", 25);
+            NStatsD.Client.Current.Gauge("test.gauge", 25);
 
             Console.Read();
         }

--- a/NStatsD/Client.cs
+++ b/NStatsD/Client.cs
@@ -47,7 +47,7 @@ namespace NStatsD
             UpdateStats(stat, -1, sampleRate);
         }
 
-        public void Guage(string stat, int value, double sampleRate = 1)
+        public void Gauge(string stat, int value, double sampleRate = 1)
         {
             var data = new Dictionary<string, string> {{stat, string.Format("{0}|g", value)}};
             Send(data, sampleRate);

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ NStatsD.Client.Current.Increment("testing.increment");
 NStatsD.Client.Current.Increment("testing.increment", 0.5); // Optional Sample Rate included on all methods
 NStatsD.Client.Current.Decrement("testing.decrement");
 NStatsD.Client.Current.Timing("testing.timing", 2345);
-NStatsD.Client.Current.Guage("testing.guage", 45);
+NStatsD.Client.Current.Gauge("testing.gauge", 45);
 ```
 # License
 


### PR DESCRIPTION
Hi Rob - thanks for the client: small typo in your method name. first pull request ever - hope this works!
