### PR TITLE
Check for Config == null and randomness of Random

### DIFF
--- a/NStatsD/Client.cs
+++ b/NStatsD/Client.cs
@@ -59,12 +59,20 @@ namespace NStatsD
             Send(dictionary, sampleRate);
         }
 
+        [ThreadStatic]
+        private static Random _random = new Random();
+
         private void Send(Dictionary<string, string> data, double sampleRate = 1)
         {
-            var random = new Random();
-            var sampledData = new Dictionary<string, string>();
-            if (sampleRate < 1 && random.Next(0, 1) <= sampleRate)
+            if (Config == null)
             {
+              return;
+            }
+
+            Dictionary<string, string> sampledData;
+            if (sampleRate < 1 && _random.Next(0, 1) <= sampleRate)
+            {
+                sampledData = new Dictionary<string, string>();
                 foreach (var stat in data.Keys)
                 {
                     sampledData.Add(stat, string.Format("{0}|@{1}", data[stat], sampleRate));
@@ -74,6 +82,7 @@ namespace NStatsD
             {
                 sampledData = data;
             }
+
             var host = Config.Server.Host;
             var port = Config.Server.Port;
             using (var client = new UdpClient(host, port))


### PR DESCRIPTION
I added a check if Config is null. If so, it will silently return instead of crashing as I think that's preferable :)

In addition, I removed the line that creates an instance of Random every time Send is called as it's possible that when Send is called multiple times within the same time window of about 15 milliseconds, two instances will get the same seed value and thus will return the same 'random' values. Not a big deal, but I replaced it with a [ThreadStatic] instance that will prevent that, will be thread-safe and faster as well (creating an instance of Random seems to be fairly expensive, relatively speaking).

I also moved the Dictionary creation in the Send method until it's actually needed.
